### PR TITLE
Add crd to 'rabbitmq' and 'all' category

### DIFF
--- a/api/v1alpha1/superstreamconsumer_types.go
+++ b/api/v1alpha1/superstreamconsumer_types.go
@@ -55,6 +55,7 @@ type SuperStreamConsumerStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:categories=all;rabbitmq
 
 // SuperStreamConsumer is the Schema for the superstreamconsumers API
 type SuperStreamConsumer struct {

--- a/config/crd/bases/rabbitmq.com_superstreamconsumers.yaml
+++ b/config/crd/bases/rabbitmq.com_superstreamconsumers.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   group: rabbitmq.com
   names:
+    categories:
+      - all
+      - rabbitmq
     kind: SuperStreamConsumer
     listKind: SuperStreamConsumerList
     plural: superstreamconsumers


### PR DESCRIPTION
## Summary Of Changes

For convenience, this adds `superstreamconsumers` crd to category `rabbitmq` (PR that does the same to all topology CRDs: https://github.com/rabbitmq/messaging-topology-operator/pull/327). 

So When you do `kubectl get rabbitmq`, you see:
```
❯ k get rabbitmq
NAME                            AGE
queue.rabbitmq.com/qq-example   8m26s

NAME                                  ALLREPLICASREADY   RECONCILESUCCESS   AGE
rabbitmqcluster.rabbitmq.com/sample   True               True               13m

NAME                            AGE
user.rabbitmq.com/user-sample   5m10s

... and all other rabbitmq resouces
```